### PR TITLE
Make QGIS Server URL configurable via ENV and read project names from database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.21
 
-RUN apk add --no-cache curl cronie
+RUN apk add --no-cache curl cronie postgresql-client
 
 WORKDIR /app
 COPY qgs_cache_preseed.sh /app/qgs_cache_preseed.sh
@@ -19,6 +19,12 @@ ENV SLEEP_INTERVAL=1
 
 # The default URL of the QGIS server to send requests to
 ENV DEFAULT_QGIS_SERVER_URL="http://qwc-qgis-server/ows/"
+
+# Connection URL for configuration database to read QGIS project files
+ENV PGSERVICEFILE="/pg_service.conf"
+ENV CONFIG_DB_URL="postgresql:///?service=qgisprojects"
+# The name of the DB schema which stores the project files in a table 'qgis_projects'.
+ENV PG_DB_SCHEMA="qwc_config"
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV SLEEP_INTERVAL=1
 ENV DEFAULT_QGIS_SERVER_URL="http://qwc-qgis-server/ows/"
 
 # Connection URL for configuration database to read QGIS project files
-ENV PGSERVICEFILE="/pg_service.conf"
+ENV PGSERVICEFILE="/srv/pg_service.conf"
 ENV CONFIG_DB_URL="postgresql:///?service=qgisprojects"
 # The name of the DB schema which stores the project files in a table 'qgis_projects'.
 ENV PG_DB_SCHEMA="qwc_config"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ ENV FCGI_INSTANCES=10
 # The sleep interval in seconds between sending requests
 ENV SLEEP_INTERVAL=1
 
+# The default URL of the QGIS server to send requests to
+ENV DEFAULT_QGIS_SERVER_URL="http://qwc-qgis-server/ows/"
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Add the `qwc-qgs-cache-preseed` container configuration to your QWC `docker-comp
       - ./volumes/preseed_services.txt:/preseed_services.txt:ro
       # OR
       # - ./volumes/qgs-resources:/data:ro
+      # OR
+      # - ./pg_service.conf:/pg_service.conf:ro
 ```
 
 Configuration
@@ -48,6 +50,7 @@ To control which QGS projects will be processed, you can:
   -  `subdir/projectname` for a QGS file located in `qgs-resources/subdir/projectname.qgs`
   - `pg/schema/projectname` for a QGS project located in a DB in schema `schema` and named `projectname`
 - Mount the `qgs-resources` dir (or whichever directory is mounted to `/data` for `qwc-qgis-server`) to `/data`, which will be then searches for projects (ending with `$QGS_EXT`).
+- Mount a postgres service configuration file to `/pg_service.conf`. The service file should contain a `[qgisprojects]` service definition. It would consider all projects located in the service DB in a specific schema. The ENV `PG_DB_SCHEMA` can be used to set the schema name (defaults to `qwc_config`). 
 
 The following environment variables can be set:
 
@@ -59,6 +62,7 @@ The following environment variables can be set:
 | `FCGI_INSTANCES`          | `10`                          | The number of FCGI instances (i.e. the number if simultaneous requests to send). |
 | `SLEEP_INTERVAL`          | `1`                           | The sleep interval in seconds between sending requests.                          |
 | `DEFAULT_QGIS_SERVER_URL` | `http://qwc-qgis-server/ows/` | The default URL of the QGIS server to send requests to.                          |
+| `PG_DB_SCHEMA`            | `qwc_config`                  | The name of the DB schema which stores QGIS projects in a table `qgis_projects`. |
 
 *Note*: You should set `FCGI_MIN_PROCESSES` equals to `FCGI_MAX_PROCESSES` in the `qwc-qgis-server` container configuration
 and `FCGI_INSTANCES` to the same number in the `qwc-qgs-cache-preseed` container configuration.

--- a/README.md
+++ b/README.md
@@ -51,13 +51,14 @@ To control which QGS projects will be processed, you can:
 
 The following environment variables can be set:
 
-| Name                 | Default     | Description                                                                      |
-|----------------------|-------------|----------------------------------------------------------------------------------|
-| `CRON_SCHEDULE`      | `0 3 * * *` | Interval at which the pre-seeding script is run. Default: every day at 03:00.    |
-| `EXECUTE_ON_STARTUP` | `0`         | Whether to run the script when the container starts.                             |
-| `QGS_EXT`            | `.qgs`      | The QGS project extension to look for (`.qgs` or `.qgz`).                        |
-| `FCGI_INSTANCES`     | `10`        | The number of FCGI instances (i.e. the number if simultaneous requests to send). |
-| `SLEEP_INTERVAL`     | `1`         | The sleep interval in seconds between sending requests.                          |
+| Name                      | Default                       | Description                                                                      |
+|---------------------------|-------------------------------|----------------------------------------------------------------------------------|
+| `CRON_SCHEDULE`           | `0 3 * * *`                   | Interval at which the pre-seeding script is run. Default: every day at 03:00.    |
+| `EXECUTE_ON_STARTUP`      | `0`                           | Whether to run the script when the container starts.                             |
+| `QGS_EXT`                 | `.qgs`                        | The QGS project extension to look for (`.qgs` or `.qgz`).                        |
+| `FCGI_INSTANCES`          | `10`                          | The number of FCGI instances (i.e. the number if simultaneous requests to send). |
+| `SLEEP_INTERVAL`          | `1`                           | The sleep interval in seconds between sending requests.                          |
+| `DEFAULT_QGIS_SERVER_URL` | `http://qwc-qgis-server/ows/` | The default URL of the QGIS server to send requests to.                          |
 
 *Note*: You should set `FCGI_MIN_PROCESSES` equals to `FCGI_MAX_PROCESSES` in the `qwc-qgis-server` container configuration
 and `FCGI_INSTANCES` to the same number in the `qwc-qgs-cache-preseed` container configuration.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add the `qwc-qgs-cache-preseed` container configuration to your QWC `docker-comp
       # OR
       # - ./volumes/qgs-resources:/data:ro
       # OR
-      # - ./pg_service.conf:/pg_service.conf:ro
+      # - ./pg_service.conf:/srv/pg_service.conf:ro
 ```
 
 Configuration
@@ -50,7 +50,7 @@ To control which QGS projects will be processed, you can:
   -  `subdir/projectname` for a QGS file located in `qgs-resources/subdir/projectname.qgs`
   - `pg/schema/projectname` for a QGS project located in a DB in schema `schema` and named `projectname`
 - Mount the `qgs-resources` dir (or whichever directory is mounted to `/data` for `qwc-qgis-server`) to `/data`, which will be then searches for projects (ending with `$QGS_EXT`).
-- Mount a postgres service configuration file to `/pg_service.conf`. The service file should contain a `[qgisprojects]` service definition. It would consider all projects located in the service DB in a specific schema. The ENV `PG_DB_SCHEMA` can be used to set the schema name (defaults to `qwc_config`). 
+- Mount a postgres service configuration file to `/srv/pg_service.conf`. The service file should contain a `[qgisprojects]` service definition. It would consider all projects located in the service DB in a specific schema. The ENV `PG_DB_SCHEMA` can be used to set the schema name (defaults to `qwc_config`). 
 
 The following environment variables can be set:
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ mkdir -p $HOME/.cache
 # Wait for qwc-qgis-server
 while true; do
   echo -n "Waiting for qwc-qgis-server"
-  status_code=$(curl -o /dev/null -s -w "%{http_code}" http://qwc-qgis-server/ows)
+  status_code=$(curl -o /dev/null -s -w "%{http_code}" ${DEFAULT_QGIS_SERVER_URL})
   if [ "$status_code" -eq 000 ]; then
     echo -n "."
     sleep 1

--- a/qgs_cache_preseed.sh
+++ b/qgs_cache_preseed.sh
@@ -14,7 +14,7 @@ if [ -f /preseed_services.txt ]; then
 elif [ -d /data ]; then
   echo "Scanning /data for projects..."
   service_names=$(find /data -name '*'${QGS_EXT} | sed "s|^/data/||; s|${QGS_EXT}$||")
-elif [ -f /pg_service.conf ]; then
+elif [ -f /srv/pg_service.conf ]; then
   echo "Reading services names from database..."
   if ! psql service="qgisprojects" -c '\q' 2>/dev/null; then
     echo "Database is not available. Exiting."

--- a/qgs_cache_preseed.sh
+++ b/qgs_cache_preseed.sh
@@ -21,7 +21,7 @@ fi
 
 echo "$service_names" | while IFS= read -r service_name; do
   echo "Processing service ${service_name}"
-  url="http://qwc-qgis-server/ows/${service_name}?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0"
+  url="${DEFAULT_QGIS_SERVER_URL}${service_name}?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0"
   echo "- Request URL: ${url}"
 
   pids=""

--- a/qgs_cache_preseed.sh
+++ b/qgs_cache_preseed.sh
@@ -14,8 +14,16 @@ if [ -f /preseed_services.txt ]; then
 elif [ -d /data ]; then
   echo "Scanning /data for projects..."
   service_names=$(find /data -name '*'${QGS_EXT} | sed "s|^/data/||; s|${QGS_EXT}$||")
+elif [ -f /pg_service.conf ]; then
+  echo "Reading services names from database..."
+  if ! psql service="qgisprojects" -c '\q' 2>/dev/null; then
+    echo "Database is not available. Exiting."
+    exit 1
+  else
+    service_names=$(psql service="qgisprojects" -t -A -c "SELECT name FROM ${PG_DB_SCHEMA}.qgis_projects;" | sed "s|^|pg/${PG_DB_SCHEMA}/|")
+  fi
 else
-  echo "No service names found. Mount a file to /preseed_services.txt or mount your projects dir to /data."
+  echo "No service names found. Mount a file to /preseed_services.txt, mount your projects dir to /data or use a database connection."
   exit 0
 fi
 


### PR DESCRIPTION
To use another QGIS Server url than `http://qwc-qgis-server/ows/` this should also be configurable via `ENV`.

Furthermore I added the possibility to read the WMS service names from a database via mounting a `pg_service.conf` file. So in this case not all project names has to be listed in `preseed_services.txt`.